### PR TITLE
Add DTLS PSK support

### DIFF
--- a/cmd/bisquitt-pub/actions.go
+++ b/cmd/bisquitt-pub/actions.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/patrickmn/go-cache"
 	"github.com/urfave/cli/v2"
 
 	snClient "github.com/energomonitor/bisquitt/client"
@@ -33,13 +34,21 @@ func handleAction() cli.ActionFunc {
 
 		useDTLS := c.Bool(DtlsFlag)
 		useSelfSigned := c.Bool(SelfSignedFlag)
+		usePSK := c.Bool(PskFlag)
+		pskCacheExpiration := c.Duration(PskCacheExpirationFlag)
+
+		pskIdentity := c.String(PskIdentityFlag)
+		pskAPITimeout := c.Duration(PSKAPITimeoutFlag)
+		pskAPIBasicAuthUsername := c.String(PSKAPIBasicAuthUsernameFlag)
+		pskAPIBasicAuthPassword := c.String(PSKAPIBasicAuthPasswordFlag)
+		pskAPIEndpoint := c.String(PSKAPIEndpointFlag)
 		certFile := c.Path(CertFlag)
 		keyFile := c.Path(KeyFlag)
 		caFile := c.Path(CAFileFlag)
 		caPath := c.Path(CAPathFlag)
 		debug := c.Bool(DebugFlag)
 
-		if useDTLS && (certFile == "" || keyFile == "") && !useSelfSigned {
+		if useDTLS && ((certFile == "" || keyFile == "") && !useSelfSigned) && !usePSK {
 			return fmt.Errorf(`options "--%s" and "--%s" are mandatory when using DTLS. Use "--%s" to generate self-signed certificate.`,
 				CertFlag, KeyFlag, SelfSignedFlag)
 		}
@@ -132,21 +141,29 @@ func handleAction() cli.ActionFunc {
 		password := []byte(c.String(PasswordFlag))
 
 		clientCfg := &snClient.ClientConfig{
-			ClientID:         clientID,
-			UseDTLS:          useDTLS,
-			SelfSigned:       useSelfSigned,
-			Insecure:         insecure,
-			Certificate:      certificate,
-			PrivateKey:       privateKey,
-			CACertificates:   caCertificates,
-			RetryDelay:       10 * time.Second,
-			RetryCount:       4,
-			ConnectTimeout:   20 * time.Second,
-			KeepAlive:        60 * time.Second,
-			CleanSession:     true,
-			PredefinedTopics: predefinedTopics,
-			User:             user,
-			Password:         password,
+			ClientID:                clientID,
+			UseDTLS:                 useDTLS,
+			UsePSK:                  usePSK,
+			PSKKeys:                 cache.New(pskCacheExpiration, 5*time.Minute),
+			PSKCacheExpiration:      pskCacheExpiration,
+			PSKIdentityHint:         pskIdentity,
+			PSKAPITimeout:           pskAPITimeout,
+			PSKAPIBasicAuthUsername: pskAPIBasicAuthUsername,
+			PSKAPIBasicAuthPassword: pskAPIBasicAuthPassword,
+			PSKAPIEndpoint:          pskAPIEndpoint,
+			SelfSigned:              useSelfSigned,
+			Insecure:                insecure,
+			Certificate:             certificate,
+			PrivateKey:              privateKey,
+			CACertificates:          caCertificates,
+			RetryDelay:              10 * time.Second,
+			RetryCount:              4,
+			ConnectTimeout:          20 * time.Second,
+			KeepAlive:               60 * time.Second,
+			CleanSession:            true,
+			PredefinedTopics:        predefinedTopics,
+			User:                    user,
+			Password:                password,
 		}
 
 		var logger util.Logger

--- a/cmd/bisquitt-pub/application.go
+++ b/cmd/bisquitt-pub/application.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/urfave/cli/v2"
 
@@ -9,25 +10,32 @@ import (
 )
 
 const (
-	HostFlag                 = "host"
-	PortFlag                 = "port"
-	DtlsFlag                 = "dtls"
-	SelfSignedFlag           = "self-signed"
-	CertFlag                 = "cert"
-	KeyFlag                  = "key"
-	CAFileFlag               = "cafile"
-	CAPathFlag               = "capath"
-	InsecureFlag             = "insecure"
-	DebugFlag                = "debug"
-	TopicFlag                = "topic"
-	MessageFlag              = "message"
-	RetainFlag               = "retain"
-	PredefinedTopicFlag      = "predefined-topic"
-	PredefinedTopicsFileFlag = "predefined-topics-file"
-	QOSFlag                  = "qos"
-	ClientIDFlag             = "client-id"
-	UserFlag                 = "user"
-	PasswordFlag             = "password"
+	HostFlag                    = "host"
+	PortFlag                    = "port"
+	DtlsFlag                    = "dtls"
+	SelfSignedFlag              = "self-signed"
+	PskFlag                     = "psk"
+	PskCacheExpirationFlag      = "psk-cache-expiration"
+	PskIdentityFlag             = "psk-identity"
+	PSKAPITimeoutFlag           = "psk-api-timeout"
+	PSKAPIBasicAuthUsernameFlag = "psk-api-basic-auth-username"
+	PSKAPIBasicAuthPasswordFlag = "psk-api-basic-auth-password"
+	PSKAPIEndpointFlag          = "psk-api-endpoint"
+	CertFlag                    = "cert"
+	KeyFlag                     = "key"
+	CAFileFlag                  = "cafile"
+	CAPathFlag                  = "capath"
+	InsecureFlag                = "insecure"
+	DebugFlag                   = "debug"
+	TopicFlag                   = "topic"
+	MessageFlag                 = "message"
+	RetainFlag                  = "retain"
+	PredefinedTopicFlag         = "predefined-topic"
+	PredefinedTopicsFileFlag    = "predefined-topics-file"
+	QOSFlag                     = "qos"
+	ClientIDFlag                = "client-id"
+	UserFlag                    = "user"
+	PasswordFlag                = "password"
 )
 
 func init() {
@@ -74,6 +82,57 @@ var Application = cli.App{
 			Usage: "generate self-signed certificate",
 			EnvVars: []string{
 				"SELF_SIGNED",
+			},
+		},
+		&cli.BoolFlag{
+			Name:  PskFlag,
+			Usage: "use PSK",
+			EnvVars: []string{
+				"PSK_ENABLED",
+			},
+		},
+		&cli.DurationFlag{
+			Name:  PskCacheExpirationFlag,
+			Usage: "PSKKeys cache expiration",
+			Value: 5 * time.Minute,
+			EnvVars: []string{
+				"PSK_CACHE_EXPIRATION",
+			},
+		},
+		&cli.StringFlag{
+			Name:  PskIdentityFlag,
+			Usage: "PSKKeys identity",
+			EnvVars: []string{
+				"PSK_IDENTITY",
+			},
+		},
+		&cli.DurationFlag{
+			Name:  PSKAPITimeoutFlag,
+			Usage: "PSKKeys API timeout",
+			Value: 5 * time.Second,
+			EnvVars: []string{
+				"PSK_API_TIMEOUT",
+			},
+		},
+		&cli.StringFlag{
+			Name:  PSKAPIBasicAuthUsernameFlag,
+			Usage: "PSKKeys API basic auth username",
+			EnvVars: []string{
+				"PSK_API_BASIC_AUTH_USERNAME",
+			},
+		},
+		&cli.StringFlag{
+			Name:  PSKAPIBasicAuthPasswordFlag,
+			Usage: "PSKKeys API basic auth password",
+			EnvVars: []string{
+				"PSK_API_BASIC_AUTH_PASSWORD",
+			},
+		},
+		&cli.StringFlag{
+			Name:  PSKAPIEndpointFlag,
+			Usage: "PSKKeys API endpoint",
+			EnvVars: []string{
+				"PSK_API_ENDPOINT",
 			},
 		},
 		&cli.PathFlag{

--- a/cmd/bisquitt-sub/application.go
+++ b/cmd/bisquitt-sub/application.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/urfave/cli/v2"
 
@@ -9,27 +10,34 @@ import (
 )
 
 const (
-	HostFlag                 = "host"
-	PortFlag                 = "port"
-	DtlsFlag                 = "dtls"
-	SelfSignedFlag           = "self-signed"
-	CertFlag                 = "cert"
-	KeyFlag                  = "key"
-	CAFileFlag               = "cafile"
-	CAPathFlag               = "capath"
-	InsecureFlag             = "insecure"
-	DebugFlag                = "debug"
-	TopicFlag                = "topic"
-	PredefinedTopicFlag      = "predefined-topic"
-	PredefinedTopicsFileFlag = "predefined-topics-file"
-	QOSFlag                  = "qos"
-	ClientIDFlag             = "client-id"
-	WillTopicFlag            = "will-topic"
-	WillMessageFlag          = "will-message"
-	WillQOSFlag              = "will-qos"
-	WillRetainFlag           = "will-retain"
-	UserFlag                 = "user"
-	PasswordFlag             = "password"
+	HostFlag                    = "host"
+	PortFlag                    = "port"
+	DtlsFlag                    = "dtls"
+	SelfSignedFlag              = "self-signed"
+	PskFlag                     = "psk"
+	PskCacheExpirationFlag      = "psk-cache-expiration"
+	PskIdentityFlag             = "psk-identity"
+	PSKAPITimeoutFlag           = "psk-api-timeout"
+	PSKAPIBasicAuthUsernameFlag = "psk-api-basic-auth-username"
+	PSKAPIBasicAuthPasswordFlag = "psk-api-basic-auth-password"
+	PSKAPIEndpointFlag          = "psk-api-endpoint"
+	CertFlag                    = "cert"
+	KeyFlag                     = "key"
+	CAFileFlag                  = "cafile"
+	CAPathFlag                  = "capath"
+	InsecureFlag                = "insecure"
+	DebugFlag                   = "debug"
+	TopicFlag                   = "topic"
+	PredefinedTopicFlag         = "predefined-topic"
+	PredefinedTopicsFileFlag    = "predefined-topics-file"
+	QOSFlag                     = "qos"
+	ClientIDFlag                = "client-id"
+	WillTopicFlag               = "will-topic"
+	WillMessageFlag             = "will-message"
+	WillQOSFlag                 = "will-qos"
+	WillRetainFlag              = "will-retain"
+	UserFlag                    = "user"
+	PasswordFlag                = "password"
 )
 
 func init() {
@@ -69,6 +77,57 @@ var Application = cli.App{
 			Usage: "use DTLS",
 			EnvVars: []string{
 				"DTLS_ENABLED",
+			},
+		},
+		&cli.BoolFlag{
+			Name:  PskFlag,
+			Usage: "use PSK",
+			EnvVars: []string{
+				"PSK_ENABLED",
+			},
+		},
+		&cli.DurationFlag{
+			Name:  PskCacheExpirationFlag,
+			Value: 5 * time.Minute,
+			Usage: "PSKKeys cache expiration",
+			EnvVars: []string{
+				"PSK_CACHE_EXPIRATION",
+			},
+		},
+		&cli.StringFlag{
+			Name:  PskIdentityFlag,
+			Usage: "PSKKeys identity",
+			EnvVars: []string{
+				"PSK_IDENTITY",
+			},
+		},
+		&cli.DurationFlag{
+			Name:  PSKAPITimeoutFlag,
+			Usage: "PSKKeys API timeout",
+			Value: 5 * time.Second,
+			EnvVars: []string{
+				"PSK_API_TIMEOUT",
+			},
+		},
+		&cli.StringFlag{
+			Name:  PSKAPIBasicAuthUsernameFlag,
+			Usage: "PSKKeys API basic auth username",
+			EnvVars: []string{
+				"PSK_API_BASIC_AUTH_USERNAME",
+			},
+		},
+		&cli.StringFlag{
+			Name:  PSKAPIBasicAuthPasswordFlag,
+			Usage: "PSKKeys API basic auth password",
+			EnvVars: []string{
+				"PSK_API_BASIC_AUTH_PASSWORD",
+			},
+		},
+		&cli.StringFlag{
+			Name:  PSKAPIEndpointFlag,
+			Usage: "PSKKeys API endpoint",
+			EnvVars: []string{
+				"PSK_API_ENDPOINT",
 			},
 		},
 		&cli.BoolFlag{

--- a/cmd/bisquitt/application.go
+++ b/cmd/bisquitt/application.go
@@ -11,27 +11,34 @@ import (
 )
 
 const (
-	MqttHostFlag             = "mqtt-host"
-	MqttPortFlag             = "mqtt-port"
-	MqttUserFlag             = "mqtt-user"
-	MqttPasswordFlag         = "mqtt-password"
-	MqttPasswordFileFlag     = "mqtt-password-file"
-	MqttTimeoutFlag          = "mqtt-timeout"
-	HostFlag                 = "host"
-	PortFlag                 = "port"
-	DtlsFlag                 = "dtls"
-	SelfSignedFlag           = "self-signed"
-	CertFlag                 = "cert"
-	KeyFlag                  = "key"
-	PredefinedTopicFlag      = "predefined-topic"
-	PredefinedTopicsFileFlag = "predefined-topics-file"
-	SyslogFlag               = "syslog"
-	DebugFlag                = "debug"
-	PerformanceLogTimeFlag   = "performance-log-time"
-	InsecureFlag             = "insecure"
-	AuthFlag                 = "auth"
-	UserFlag                 = "user"
-	GroupFlag                = "group"
+	MqttHostFlag                = "mqtt-host"
+	MqttPortFlag                = "mqtt-port"
+	MqttUserFlag                = "mqtt-user"
+	MqttPasswordFlag            = "mqtt-password"
+	MqttPasswordFileFlag        = "mqtt-password-file"
+	MqttTimeoutFlag             = "mqtt-timeout"
+	HostFlag                    = "host"
+	PortFlag                    = "port"
+	DtlsFlag                    = "dtls"
+	PskFlag                     = "psk"
+	PskCacheExpirationFlag      = "psk-cache-expiration"
+	PskIdentityFlag             = "psk-identity"
+	PSKAPITimeoutFlag           = "psk-api-timeout"
+	PSKAPIBasicAuthUsernameFlag = "psk-api-basic-auth-username"
+	PSKAPIBasicAuthPasswordFlag = "psk-api-basic-auth-password"
+	PSKAPIEndpointFlag          = "psk-api-endpoint"
+	SelfSignedFlag              = "self-signed"
+	CertFlag                    = "cert"
+	KeyFlag                     = "key"
+	PredefinedTopicFlag         = "predefined-topic"
+	PredefinedTopicsFileFlag    = "predefined-topics-file"
+	SyslogFlag                  = "syslog"
+	DebugFlag                   = "debug"
+	PerformanceLogTimeFlag      = "performance-log-time"
+	InsecureFlag                = "insecure"
+	AuthFlag                    = "auth"
+	UserFlag                    = "user"
+	GroupFlag                   = "group"
 )
 
 var Application = cli.App{
@@ -107,6 +114,57 @@ var Application = cli.App{
 			Usage: "use DTLS",
 			EnvVars: []string{
 				"DTLS_ENABLED",
+			},
+		},
+		&cli.BoolFlag{
+			Name:  PskFlag,
+			Usage: "use PSK",
+			EnvVars: []string{
+				"PSK_ENABLED",
+			},
+		},
+		&cli.DurationFlag{
+			Name:  PskCacheExpirationFlag,
+			Value: 5 * time.Minute,
+			Usage: "PSKKeys cache expiration",
+			EnvVars: []string{
+				"PSK_CACHE_EXPIRATION",
+			},
+		},
+		&cli.StringFlag{
+			Name:  PskIdentityFlag,
+			Usage: "PSKKeys identity",
+			EnvVars: []string{
+				"PSK_IDENTITY",
+			},
+		},
+		&cli.DurationFlag{
+			Name:  PSKAPITimeoutFlag,
+			Usage: "PSKKeys API timeout",
+			Value: 5 * time.Second,
+			EnvVars: []string{
+				"PSK_API_TIMEOUT",
+			},
+		},
+		&cli.StringFlag{
+			Name:  PSKAPIBasicAuthUsernameFlag,
+			Usage: "PSKKeys API basic auth username",
+			EnvVars: []string{
+				"PSK_API_BASIC_AUTH_USERNAME",
+			},
+		},
+		&cli.StringFlag{
+			Name:  PSKAPIBasicAuthPasswordFlag,
+			Usage: "PSKKeys API basic auth password",
+			EnvVars: []string{
+				"PSK_API_BASIC_AUTH_PASSWORD",
+			},
+		},
+		&cli.StringFlag{
+			Name:  PSKAPIEndpointFlag,
+			Usage: "PSKKeys API endpoint",
+			EnvVars: []string{
+				"PSK_API_ENDPOINT",
 			},
 		},
 		&cli.BoolFlag{

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/eclipse/paho.mqtt.golang v1.3.5
+	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/pion/dtls/v2 v2.1.3
 	github.com/pion/udp v0.1.1
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/eclipse/paho.mqtt.golang v1.3.5 h1:sWtmgNxYM9P2sP+xEItMozsR3w0cqZFlqnNN1bdl41Y=
 github.com/eclipse/paho.mqtt.golang v1.3.5/go.mod h1:eTzb4gxwwyWpqBUHGQZ4ABAV7+Jgm1PklsYT/eo8Hcc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
+github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pion/dtls/v2 v2.1.3 h1:3UF7udADqous+M2R5Uo2q/YaP4EzUoWKdfX2oscCUio=
 github.com/pion/dtls/v2 v2.1.3/go.mod h1:o6+WvyLDAlXF7YiPB/RlskRoeK+/JtuaZa5emwQcWus=
 github.com/pion/logging v0.2.2 h1:M9+AIj/+pxNsDfAT64+MAVgJO0rsyLnoJKCqf//DoeY=

--- a/util/pskclient.go
+++ b/util/pskclient.go
@@ -1,0 +1,56 @@
+package util
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// GetPSKKeyFromAPI retrieves a pre-shared key from the PSKKeys API.
+func GetPSKKeyFromAPI(hint string, endpoint string, username string, password string, timeout time.Duration, logger Logger) ([]byte, bool) {
+	req, err := http.NewRequest("GET", fmt.Sprintf(endpoint+"/%s", hint), nil)
+	if err != nil {
+		logger.Error("Error in creating request: %s", err)
+		return nil, false
+	}
+
+	req.SetBasicAuth(username, password)
+	client := &http.Client{}
+	client.Timeout = timeout
+	resp, err := client.Do(req)
+
+	if err != nil {
+		logger.Error("Error in sending request: %s", err)
+		return nil, false
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		logger.Debug("ID not found")
+		return nil, false
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		logger.Error("Error in reading response body: %s", err)
+		return nil, false
+	}
+
+	type Response struct {
+		Client string `json:"client"`
+		PSK    []byte `json:"psk"`
+	}
+
+	var response Response
+
+	err = json.Unmarshal(body, &response)
+	if err != nil {
+		logger.Error("Error in unmarshalling response body: %s", err)
+		return nil, false
+	}
+
+	return response.PSK, true
+}


### PR DESCRIPTION
### Summary:

Added support for PSK (DTLS preshared-key) in BISQUITT, enhancing security options. This feature integrates an HTTP API to obtain PSK keys, introducing API caching to optimize performance. With this update, users have the flexibility to choose between certificates and PSK for authentication, though both methods cannot be used simultaneously.

### Changes:

- Implemented PSK (DTLS preshared-key) support in BISQUITT.
- Integrated HTTP API for fetching PSK keys.
- Introduced API caching mechanism to reduce redundant API calls.
- Provided option for users to choose between certificates and PSK for authentication.

Notes:

- Users must select either certificates or PSK for authentication; simultaneous use of both methods is not supported.
- An example implementation of the HTTP API will be published in another [repository](https://github.com/energostack/bisquitt-psk/pull/1) following the BISQUITT release.